### PR TITLE
Added x-token-passphrase to the allowed headers

### DIFF
--- a/token-management-samples/token-service-sample/index.js
+++ b/token-management-samples/token-service-sample/index.js
@@ -7,8 +7,8 @@ exports.tokenService = async (req, res) => {
   // handle preflight requests here
   if (req.method === "OPTIONS") {
     res.set("Access-Control-Allow-Methods", "GET, POST");
-    res.set("Access-Control-Allow-Headers", "Content-Type, Accept");
-    return res.statusSend(204);
+    res.set("Access-Control-Allow-Headers", "Content-Type, Accept, x-token-passphrase");
+    return res.status(204).Send("");
   }
 
   // callback request


### PR DESCRIPTION
For the token-service-sample:

Cross-Origin Resource Sharing (CORS) was failing.  There was a missing header field (x-token-passphrase) and a typo in the response.